### PR TITLE
chore: remove name and version

### DIFF
--- a/contracts/handler/ExtensibleFallbackHandler.sol
+++ b/contracts/handler/ExtensibleFallbackHandler.sol
@@ -18,9 +18,7 @@ contract ExtensibleFallbackHandler is FallbackHandler, SignatureVerifierMuxer, T
      */
     function _supportsInterface(bytes4 interfaceId) internal pure override returns (bool) {
         return interfaceId == type(ISignatureVerifierMuxer).interfaceId
-            || interfaceId == type(ERC165Handler).interfaceId
-            || interfaceId == type(IFallbackHandler).interfaceId
-            || interfaceId == type(ERC721TokenReceiver).interfaceId
-            || interfaceId == type(ERC1155TokenReceiver).interfaceId;
+            || interfaceId == type(ERC165Handler).interfaceId || interfaceId == type(IFallbackHandler).interfaceId
+            || interfaceId == type(ERC721TokenReceiver).interfaceId || interfaceId == type(ERC1155TokenReceiver).interfaceId;
     }
 }

--- a/contracts/handler/ExtensibleFallbackHandler.sol
+++ b/contracts/handler/ExtensibleFallbackHandler.sol
@@ -4,23 +4,23 @@ pragma solidity >=0.7.0 <0.9.0;
 import "./extensible/FallbackHandler.sol";
 import "./extensible/SignatureVerifierMuxer.sol";
 import "./extensible/TokenCallbacks.sol";
-import "./extensible/IERC165Handler.sol";
+import "./extensible/ERC165Handler.sol";
 
 /**
  * @title ExtensibleFallbackHandler - A fully extensible fallback handler for Safes
  * @dev Designed to be used with Safe >= 1.3.0.
  * @author mfw78 <mfw78@rndlabs.xyz>
  */
-contract ExtensibleFallbackHandler is FallbackHandler, SignatureVerifierMuxer, TokenCallbacks, IERC165Handler {
-    string public constant NAME = "Extensible Fallback Handler";
-    string public constant VERSION = "1.0.0";
-
+contract ExtensibleFallbackHandler is FallbackHandler, SignatureVerifierMuxer, TokenCallbacks, ERC165Handler {
     /**
      * Specify specific interfaces (ERC721 + ERC1155) that this contract supports.
      * @param interfaceId The interface ID to check for support
      */
     function _supportsInterface(bytes4 interfaceId) internal pure override returns (bool) {
-        return interfaceId == type(ERC721TokenReceiver).interfaceId
+        return interfaceId == type(ISignatureVerifierMuxer).interfaceId
+            || interfaceId == type(ERC165Handler).interfaceId
+            || interfaceId == type(IFallbackHandler).interfaceId
+            || interfaceId == type(ERC721TokenReceiver).interfaceId
             || interfaceId == type(ERC1155TokenReceiver).interfaceId;
     }
 }

--- a/contracts/handler/extensible/Base.sol
+++ b/contracts/handler/extensible/Base.sol
@@ -72,45 +72,6 @@ abstract contract ExtensibleBase is HandlerContext {
         sender = _msgSender();
     }
 
-    // /**
-    //  * Try to call a static (view-only) fallback method, if one is set
-    //  */
-    // function _tryStaticFallbackMethod() internal view {
-    //     (Safe safe, address sender,, address handler) = _getContextAndHandler();
-    //     // If a handler is set, call it and return the result
-    //     if (handler != address(0)) {
-    //         IStaticFallbackMethod(handler).handle(safe, sender, msg.data[:msg.data.length - 20]);
-    //         // Return the result of the call to the FallbackManager
-    //         _return();
-    //     }
-    // }
-
-    // /**
-    //  * Try to call a non-static (state-changing) fallback method, if one is set
-    //  */
-    // function _tryFallbackMethod() internal {
-    //     (Safe safe, address sender,, address handler) = _getContextAndHandler();
-    //     // If a handler is set, call it and return the result
-    //     if (handler != address(0)) {
-    //         IFallbackMethod(handler).handle(safe, sender, msg.data[:msg.data.length - 20]);
-    //         // Return the result of the call to the FallbackManager
-    //         _return();
-    //     }
-    // }
-
-    // /**
-    //  * Return the result of the call to the FallbackManager
-    //  * @dev This is a helper function to avoid code duplication in the `_tryStaticFallbackMethod` and `_tryFallbackMethod` functions.
-    //  *      In order to generalise the return value of the call to the FallbackManager, we use assembly to copy the return data
-    //  *      of the call to the handler contract to the return data of the call to the FallbackManager.
-    //  *      This is necessary because the return value of the call to the handler contract is not known at compile time.
-    //  */
-    // function _return() internal pure {
-    //     assembly {
-    //         return(0, returndatasize())
-    //     }
-    // }
-
     /**
      * Get the context and the method handler applicable to the current call
      * @return safe The safe whose FallbackManager is making this call

--- a/contracts/handler/extensible/ERC165Handler.sol
+++ b/contracts/handler/extensible/ERC165Handler.sol
@@ -77,8 +77,7 @@ abstract contract ERC165Handler is ExtensibleBase, IERC165Handler {
      */
     function supportsInterface(bytes4 interfaceId) external view returns (bool) {
         return interfaceId == type(IERC165).interfaceId || interfaceId == type(IERC165Handler).interfaceId
-            || _supportsInterface(interfaceId)
-            || safeInterfaces[Safe(payable(_manager()))][interfaceId];
+            || _supportsInterface(interfaceId) || safeInterfaces[Safe(payable(_manager()))][interfaceId];
     }
 
     // --- internal ---

--- a/contracts/handler/extensible/FallbackHandler.sol
+++ b/contracts/handler/extensible/FallbackHandler.sol
@@ -3,13 +3,17 @@ pragma solidity >=0.7.0 <0.9.0;
 
 import "./Base.sol";
 
+interface IFallbackHandler {
+    function setSafeMethod(bytes4 selector, bytes32 newMethod) external;
+}
+
 /**
  * @title FallbackHandler - A fully extensible fallback handler for Safes
  * @dev This contract provides a fallback handler for Safes that can be extended with custom fallback handlers
  *      for specific methods.
  * @author mfw78 <mfw78@rndlabs.xyz>
  */
-abstract contract FallbackHandler is ExtensibleBase {
+abstract contract FallbackHandler is ExtensibleBase, IFallbackHandler {
     // --- setters ---
 
     /**
@@ -17,7 +21,7 @@ abstract contract FallbackHandler is ExtensibleBase {
      * @param selector The `bytes4` selector of the method to set the handler for
      * @param newMethod A contract that implements the `IFallbackMethod` or `IStaticFallbackMethod` interface
      */
-    function setSafeMethod(bytes4 selector, bytes32 newMethod) public onlySelf {
+    function setSafeMethod(bytes4 selector, bytes32 newMethod) public override onlySelf {
         _setSafeMethod(Safe(payable(_msgSender())), selector, newMethod);
     }
 

--- a/contracts/handler/extensible/SignatureVerifierMuxer.sol
+++ b/contracts/handler/extensible/SignatureVerifierMuxer.sol
@@ -145,21 +145,6 @@ abstract contract SignatureVerifierMuxer is ExtensibleBase, ERC1271, ISignatureV
     }
 
     /**
-     * @notice Legacy EIP-1271 signature validation method.
-     * @dev Implementation of ISignatureValidator (see `interfaces/ISignatureValidator.sol`)
-     * @param _data Arbitrary length data signed on the behalf of address(msg.sender).
-     * @param _signature Signature byte array associated with _data.
-     * @return a bool upon valid or invalid signature with corresponding _data.
-     */
-    function isValidSignature(bytes memory _data, bytes memory _signature) public view override returns (bytes4) {
-        // Caller should be a Safe
-        Safe safe = Safe(payable(msg.sender));
-        return defaultIsValidSignature(safe, _data, _signature) == ERC1271.isValidSignature.selector
-            ? EIP1271_MAGIC_VALUE
-            : bytes4(0);
-    }
-
-    /**
      * Default Safe signature validation (approved hashes / threshold signatures)
      * @param safe The safe being asked to validate the signature
      * @param _hash Hash of the data that is signed

--- a/contracts/handler/extensible/SignatureVerifierMuxer.sol
+++ b/contracts/handler/extensible/SignatureVerifierMuxer.sol
@@ -100,9 +100,9 @@ abstract contract SignatureVerifierMuxer is ExtensibleBase, ERC1271, ISignatureV
      * @param signature The signature to be verified
      * @return magic Standardised ERC1271 return value
      */
-    function isValidSignature(bytes32 _hash, bytes calldata signature) external override view returns (bytes4 magic) {
+    function isValidSignature(bytes32 _hash, bytes calldata signature) external view override returns (bytes4 magic) {
         (Safe safe, address sender) = _getContext();
-        
+
         bytes4 sigSelector;
         // solhint-disable-next-line no-inline-assembly
         assembly {
@@ -155,8 +155,9 @@ abstract contract SignatureVerifierMuxer is ExtensibleBase, ERC1271, ISignatureV
         view
         returns (bytes4 magic)
     {
-        bytes memory messageData =
-            EIP712.encodeMessageData(safe.domainSeparator(), SAFE_MSG_TYPEHASH, abi.encode(keccak256(abi.encode(_hash))));
+        bytes memory messageData = EIP712.encodeMessageData(
+            safe.domainSeparator(), SAFE_MSG_TYPEHASH, abi.encode(keccak256(abi.encode(_hash)))
+        );
         bytes32 messageHash = keccak256(messageData);
         if (signature.length == 0) {
             // approved hashes
@@ -193,6 +194,8 @@ library EIP712 {
         pure
         returns (bytes memory)
     {
-        return abi.encodePacked(bytes1(0x19), bytes1(0x01), domainSeparator, keccak256(abi.encodePacked(typeHash, message)));
+        return abi.encodePacked(
+            bytes1(0x19), bytes1(0x01), domainSeparator, keccak256(abi.encodePacked(typeHash, message))
+        );
     }
 }

--- a/contracts/handler/extensible/SignatureVerifierMuxer.sol
+++ b/contracts/handler/extensible/SignatureVerifierMuxer.sol
@@ -141,7 +141,7 @@ abstract contract SignatureVerifierMuxer is ExtensibleBase, ERC1271, ISignatureV
         }
 
         // domainVerifier doesn't exist or the signature is invalid for the domain - fall back to the default
-        return defaultIsValidSignature(safe, abi.encode(_hash), signature);
+        return defaultIsValidSignature(safe, _hash, signature);
     }
 
     /**
@@ -150,13 +150,13 @@ abstract contract SignatureVerifierMuxer is ExtensibleBase, ERC1271, ISignatureV
      * @param _hash Hash of the data that is signed
      * @param signature The signature to be verified
      */
-    function defaultIsValidSignature(Safe safe, bytes memory _hash, bytes memory signature)
+    function defaultIsValidSignature(Safe safe, bytes32 _hash, bytes memory signature)
         internal
         view
         returns (bytes4 magic)
     {
         bytes memory messageData =
-            EIP712.encodeMessageData(safe.domainSeparator(), SAFE_MSG_TYPEHASH, abi.encode(keccak256(_hash)));
+            EIP712.encodeMessageData(safe.domainSeparator(), SAFE_MSG_TYPEHASH, abi.encode(keccak256(abi.encode(_hash))));
         bytes32 messageHash = keccak256(messageData);
         if (signature.length == 0) {
             // approved hashes

--- a/test/handlers/ExtensibleFallbackHandler.spec.ts
+++ b/test/handlers/ExtensibleFallbackHandler.spec.ts
@@ -133,23 +133,6 @@ describe("ExtensibleFallbackHandler", async () => {
         };
     });
 
-    describe("Metadata", async () => {
-        it("should return the correct name when called directly", async () => {
-            const { handler } = await setupTests();
-            expect(await handler.NAME()).to.be.eq("Extensible Fallback Handler");
-        });
-
-        it("should return the correct name when called via safe", async () => {
-            const { validator } = await setupTests();
-            expect(await validator.NAME()).to.be.eq("Extensible Fallback Handler");
-        });
-
-        it("should return the correct version when called directly", async () => {
-            const { handler } = await setupTests();
-            expect(await handler.VERSION()).to.be.eq("1.0.0");
-        });
-    });
-
     describe("Token Callbacks", async () => {
         describe("ERC1155", async () => {
             it("to handle onERC1155Received", async () => {


### PR DESCRIPTION
This PR:

1. Removes the `NAME` and `VERSION` from `ExtensibleFallbackHandler`.
2. Provides interface definitions for `ISignatureVerifierMuxer`, `IFallbackHandler`, and `IERC165Handler`.